### PR TITLE
Update ai-confs.csv

### DIFF
--- a/data/ai-confs.csv
+++ b/data/ai-confs.csv
@@ -2,11 +2,13 @@ AAAI,AAAI,1
 NIPS,NIPS/NeurIPS,1
 NeurIPS,NIPS/NeurIPS,1
 IJCAI,IJCAI,1
+ICML,ICML,1
 UAI,UAI,3
 GECCO,GECCO,3
 ACL (1),ACL,3
 LAK,LAK,3
 AAMAS,AAMAS,3
+ICAPS,ICAPS,3
 EMNLP,EMNLP,3
 EACL (1),EACL,3
 AISTATS,AISTATS,3
@@ -27,3 +29,9 @@ Knowl. Based Syst.,Knowledge-Based Syst.,6
 Fuzzy Sets Syst.,Fuzzy Sets and Systems,5
 Soft Comput.,Soft Computing,7
 Int. J. Approx. Reason.,Int. J. Approx. Reasoning,5
+Appl. Intell.,Applied Intelligence, 5
+ACM Trans. Intell. Syst. Technol.,ACM Transactions on Intelligent Systems and Technology,5
+Auton. Agents Multi Agent Syst.,Autonomous Agents and Multi-Agent Systems,4
+Knowl. Eng. Rev.,The Knowledge Engineering Review,5
+Artif. Intell. Law,Artificial Intelligence and Law,6
+AI Mag.,AI Magazine,5


### PR DESCRIPTION
Adding more AI conferences
I'm not sure what the number in the third column means, but I assumed is some kind of ranking/weight, so I just copied the number from a conference with a similar Qualis ranking. If this is indeed the correct interpretation, then you may need to change the rankings of these two conferences:

- Artif. Intell.,Artificial Intelligence,5
- J. Artif. Intell. Res.,Journal of AI Research,5

As they are the premier journals in AI. If this is the case, let me know and I can further edit this CSV to adjust the rankings as understood by the community. 